### PR TITLE
[add]수강신청 성공한 학생에게 성공 메일 보내는 API

### DIFF
--- a/src/main/java/com/classMetabus/web/Admin/controller/MailController.java
+++ b/src/main/java/com/classMetabus/web/Admin/controller/MailController.java
@@ -18,10 +18,16 @@ import org.springframework.web.bind.annotation.*;
 public class MailController {
     private final MailService mailService;
 
-    @PostMapping("/send")
-    public ResponseEntity sendMail(@RequestBody SendMailRequest request){
-        return new ResponseEntity(CommonResponse.res(true,StatusCode.OK, "메일전송을 성공했습니다.",mailService.sendMail(request.getInstructorId(), request.getContext())), null, HttpStatus.OK);
+    @PostMapping("/sendALL")
+    public ResponseEntity sendMailAll(@RequestBody SendMailRequest request){
+        return new ResponseEntity(CommonResponse.res(true,StatusCode.OK, "메일전송을 성공했습니다.",mailService.sendMailAll(request.getInstructorId(), request.getContext())), null, HttpStatus.OK);
     }
+
+    @PostMapping("/sendLectureSignUpSuccess")
+    public ResponseEntity sendMailLectureSignUpSuccess(@RequestBody SendMailRequest request){
+        return new ResponseEntity(CommonResponse.res(true,StatusCode.OK, "수강신청 성공 메일전송을 성공했습니다.",mailService.sendMailLectureSignUpSuccess(request.getStudentId(), request.getLectureId())), null, HttpStatus.OK);
+    }
+    /*
     /*
     // 미사용
     @GetMapping("/log")

--- a/src/main/java/com/classMetabus/web/Admin/dto/mail/SendMailRequest.java
+++ b/src/main/java/com/classMetabus/web/Admin/dto/mail/SendMailRequest.java
@@ -10,4 +10,6 @@ import lombok.NoArgsConstructor;
 public class SendMailRequest {
     private Integer instructorId;
     private String context;
+    private Integer studentId;
+    private Integer lectureId;
 }

--- a/src/main/java/com/classMetabus/web/Admin/service/MailService.java
+++ b/src/main/java/com/classMetabus/web/Admin/service/MailService.java
@@ -1,12 +1,8 @@
 package com.classMetabus.web.Admin.service;
 
 
-import com.classMetabus.web.Admin.domain.Instructor;
-import com.classMetabus.web.Admin.domain.MailLog;
-import com.classMetabus.web.Admin.domain.Student;
-import com.classMetabus.web.Admin.repository.InstructorLoginRepository;
-import com.classMetabus.web.Admin.repository.MailLogRepository;
-import com.classMetabus.web.Admin.repository.StudentLoginRepository;
+import com.classMetabus.web.Admin.domain.*;
+import com.classMetabus.web.Admin.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,10 +22,11 @@ public class MailService {
     private final StudentLoginRepository studentLoginRepository;
     private final InstructorLoginRepository instructorLoginRepository;
     private final MailLogRepository mailLogRepository;
-
+    private final LectureRepository lectureRepository;
+    private final StudentListRepository studentListRepository;
     private final JavaMailSender javaMailSender;
 
-    public List<String> sendMail(Integer instructorId, String context){
+    public List<String> sendMailAll(Integer instructorId, String context){
         List<Student> studentList = studentLoginRepository.findAll();
         Optional<Instructor> instructor = instructorLoginRepository.findById(instructorId);
 
@@ -67,6 +64,25 @@ public class MailService {
 
         }
         return toUserList;
+    }
+    public Optional<Student> sendMailLectureSignUpSuccess(Integer studentId, Integer lectureId) {
+        Optional<Student> signUpStudent = studentLoginRepository.findById(studentId);
+        Optional<StudentList> stuList = studentListRepository.findIdByStudent_IdAndLecture_id(studentId, lectureId);
+
+        if (stuList.isPresent()) {
+            Optional<Lecture> lecture = lectureRepository.findById(lectureId);
+            SimpleMailMessage lectureSignUpMailMessage = new SimpleMailMessage();
+            lectureSignUpMailMessage.setTo(stuList.get().getStudent().getEmail());
+            lectureSignUpMailMessage.setSubject("[수강신청]"+ lecture.get().getName() + " 수강 신청 성공 메일");
+            lectureSignUpMailMessage.setText(lecture.get().getStartTime()+"시" +lecture.get().getName() + "수업 수강 신청에 성공하였습니다.");
+            javaMailSender.send(lectureSignUpMailMessage);
+
+
+        } // 수강신청 실패시
+
+        return signUpStudent;
+
+        // 메일 로그 만들어야함
     }
 
     /*

--- a/src/main/java/com/classMetabus/web/Admin/service/MailService.java
+++ b/src/main/java/com/classMetabus/web/Admin/service/MailService.java
@@ -70,11 +70,10 @@ public class MailService {
         Optional<StudentList> stuList = studentListRepository.findIdByStudent_IdAndLecture_id(studentId, lectureId);
 
         if (stuList.isPresent()) {
-            Optional<Lecture> lecture = lectureRepository.findById(lectureId);
             SimpleMailMessage lectureSignUpMailMessage = new SimpleMailMessage();
             lectureSignUpMailMessage.setTo(stuList.get().getStudent().getEmail());
-            lectureSignUpMailMessage.setSubject("[수강신청]"+ lecture.get().getName() + " 수강 신청 성공 메일");
-            lectureSignUpMailMessage.setText(lecture.get().getStartTime()+"시" +lecture.get().getName() + "수업 수강 신청에 성공하였습니다.");
+            lectureSignUpMailMessage.setSubject("[수강신청]  "+ stuList.get().getLecture().getId() + "  수강 신청 성공 메일");
+            lectureSignUpMailMessage.setText(stuList.get().getLecture().getStartTime() +"  " + stuList.get().getLecture().getName() + "  수업 수강 신청에 성공하였습니다.");
             javaMailSender.send(lectureSignUpMailMessage);
 
 


### PR DESCRIPTION
# 작업목록
1. 기존 http://localhost:8088/api/mail/send --> http://localhost:8088/api/mail/sendAll
2. POST http://localhost:8088/api/mail/sendLectureSignUpSuccess
request
{
    "studentId":"1",
    "lectureId":"1"
}